### PR TITLE
Get the link for option info

### DIFF
--- a/cmd/twitter/twitter.go
+++ b/cmd/twitter/twitter.go
@@ -19,14 +19,14 @@ func doSpace(id string, info bool) error {
    if err != nil {
       return err
    }
+   source, err := guest.Source(space)
+   if err != nil {
+      return err
+   }
    if info {
       fmt.Println(space)
+      fmt.Println("LINK", source.Location)
    } else {
-      source, err := guest.Source(space)
-      if err != nil {
-         return err
-      }
-      fmt.Println("GET", source.Location)
       res, err := http.Get(source.Location)
       if err != nil {
          return err


### PR DESCRIPTION
It could be useful to get the URL link to play the space with option -i.