### PR TITLE
Added Youtube LiveStreaming URLS

### DIFF
--- a/youtube/player.go
+++ b/youtube/player.go
@@ -28,6 +28,9 @@ type Player struct {
    StreamingData struct {
       AdaptiveFormats Formats
       Formats Formats
+      DashManifestUrl    string `json:"dashManifestUrl"`
+		HLSManifestUrl     string `json:"hlsManifestUrl"`
+		OnesieStreamingUrl string `json:"onesieStreamingUrl"`
    }
 }
 


### PR DESCRIPTION
Was testing some YouTube URL's to see if I could replace my current solution with this library and noticed that it did not handle YouTube live streams e.g Lofi hip hop radio https://www.youtube.com/watch?v=5qap5aO4i9A 

So here is a tiny PR that adds the HLS and Dash manifests to the player Streaming Data section